### PR TITLE
Build Paella RPMs On Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,24 @@
 ---
-sudo: false
+sudo: true
 
 language: java
-jdk: oraclejdk7
+
+jdk: oraclejdk8
+
+before_install:
+   - sudo apt-get install rpm
+
+script:
+   - mvn -B clean install
+   - mkdir -p ~/rpmbuild/SOURCES
+   - cp target/*jar ~/rpmbuild/SOURCES
+   - export VERSION=$(sed -n '0,/^.*<version>\(.*\)<\/version>.*$/s//\1/p' pom.xml)
+   - echo "%version ${VERSION}" >> "${HOME}/.rpmmacros"
+   - echo "%buildno ${TRAVIS_BUILD_NUMBER}" >> "${HOME}/.rpmmacros"
+   - echo "%commit ${TRAVIS_COMMIT}" >> "${HOME}/.rpmmacros"
+   - rpmbuild -ba paella-opencast.spec
+
+after_success:
+   - curl -i -u "${PKGUPLOADUSER}:${PKGUPLOADPASS}"
+     -F file=@${HOME}/rpmbuild/RPMS/noarch/paella-opencast-${VERSION}-${TRAVIS_BUILD_NUMBER}.${TRAVIS_COMMIT}.noarch.rpm
+     https://pkg.opencast.org/upload

--- a/paella-opencast.spec
+++ b/paella-opencast.spec
@@ -1,0 +1,57 @@
+# vim: et:ts=3:sw=3:sts=3
+
+# Call with:
+# rpmbuild ... -D version=<VERSION> ...
+
+%global __os_install_post /usr/lib/rpm/brp-compress %{nil}
+%define __requires_exclude_from ^.*\\.jar$
+%define __provides_exclude_from ^.*\\.jar$
+
+Name:          paella-opencast
+Summary:       Paella Player for Opencast
+Version:       %{version}
+Release:       %{buildno}.%{commit}%{?dist}
+License:       GPLv3+
+
+Source:        paella-engage-ui-%{version}.jar
+URL:           https://github.com/polimediaupv/paella-matterhorn
+BuildRoot:     %{_tmppath}/%{name}-root
+
+BuildArch: noarch
+
+
+%description
+The Paella (pronounce “paeja”) Player is a HTML5 multistream video player
+capable of playing multiple audio & video streams synchronously and supporting
+a number of user plugins. It is specially designed for lecture recordings, like
+Matterhorn Lectures or Polimedia pills.
+
+By using Paella students can view both the lecture hall and the teacher's
+screen, get info about the lecture (slides, OCR, series videos, footprints) and
+interact with the lecture (views, comments). Teachers can also soft edit the
+lecture to set the start and end point or make breaks in the recording.
+
+
+%prep
+
+
+%build
+
+
+%install
+rm -rf %{buildroot}
+install -p -d -m 0755 %{buildroot}%{_datadir}/opencast/deploy
+install -p -m 644 %{SOURCE0} %{buildroot}%{_datadir}/opencast/deploy/
+
+%clean
+rm -rf %{buildroot}
+
+
+%files
+%defattr(-,root,root,-)
+%{_datadir}/opencast/deploy/
+
+
+%changelog
+* Fri Jul 07 2017 Lars Kiesow <lkiesow@uos.de> - 5.2.1-1
+- Initial Paella build


### PR DESCRIPTION
This patch adjusts the Travis configuration to actually build Paella on
Travis to report possible problems. Additionally, RPMs are build for
each version and sent to pkg.opencast.org.

Note that for a successful upload both the variables PKGUPLOADUSER and
PKGUPLOADPASS need to be set in Travis. Although, tests will not fail if
they are not set.